### PR TITLE
feat(2353): move external-user endpoint from interoperability to back-office

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -153,11 +153,18 @@ avenirs.security.context.signature.current-kid=v2
 avenirs.security.context.signature.ttl-seconds=300
 avenirs.security.context.signature.algorithm=HmacSHA256
 
+# Back office
+avenirs.back-office.base-url=http://localhost:10010/back-office
+avenirs.back-office.trace.config.endpoint=${avenirs.back-office.base-url}/config/traces
+avenirs.back-office.institution.config.endpoint=${avenirs.back-office.base-url}/config/institution
+avenirs.back-office.external-user.endpoint=${avenirs.back-office.base-url}/external-users
+avenirs.back-office.external-user.get-by-eppn=${avenirs.back-office.external-user.endpoint}/eppn
+avenirs.back-office.api-key=ENC(tfNG7vGZMGuUCwfLTfcuIcRY6zp5yg3sHsUrG+3Ys7uEOGE+swRhezj4/jmWJzg4dmoGxH6RhMQ=)
+
 # Interoperability
 avenirs.interoperability.base-url=http://avenirs-portfolio-interoperability:10020/interoperability
 avenirs.interoperability.actuator.health=http://avenirs-portfolio-interoperability:10020/health/seeding
 avenirs.interoperability.api-key=ENC(tfNG7vGZMGuUCwfLTfcuIcRY6zp5yg3sHsUrG+3Ys7uEOGE+swRhezj4/jmWJzg4dmoGxH6RhMQ=)
-avenirs.interoperability.external-user.endpoint=${avenirs.interoperability.base-url}/external-users
 avenirs.microservice.dependency.behaviour=WAIT
 avenirs.microservice.dependency.timeout.seconds=600
 avenirs.microservice.dependency.retry.interval.seconds=10


### PR DESCRIPTION
## 📝 Pull Request Description

### Brief description of changes applied
> Moves the external-user endpoint configuration from the interoperability service to the back-office service, adding dedicated back-office configuration properties (base URL, trace config, institution config, external-user endpoints, API key) and removing the now-obsolete external-user endpoint entry under interoperability. Also updates the `avenirs-portfolio-common` submodule reference.

---

### Reference to an Issue, Feature, Task, User Story or another PR
> Closes https://github.com/avenirs-esr/AVENIRS-Project/issues/2353

---

### Documentation
> No documentation updates required beyond the configuration changes in `application.properties`.

---

### Target Branch
> `develop`

---

### Additional Notes
> N/A

---

### Known Limitations or Side Effects
> N/A

---

## ✅ Checklist

Please make sure you have addressed the following before submitting:

- [ ] a11y tested (if the PR includes frontend changes)
- [ ] Tests provided (including unit and integration tests for both frontend and backend)
- [ ] i18n handled (texts are translated)
- [ ] Performance tests
- [ ] No unnecessary code (e.g., debug logs, commented code)
- [ ] Code style and formatting rules respected (linting, conventions, etc.)
- [ ] Semantic Versioning respected
- [ ] Add to `CHANGELOG.md` file all properties and database change and details for the update process